### PR TITLE
feat: hybrid keyless/keyed OSINT API layer with VirusTotal and Hunter…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,15 +3,22 @@
 # upgrades that engine from anonymous scraping to the official API; missing
 # keys are ignored and the tool falls back gracefully. Requires python-dotenv
 # (already in requirements.txt) — without it, plain environment variables still work.
+#
+# TIP: instead of editing this file by hand, run `professor-osint --config-api`,
+# an interactive wizard that validates each key and saves it to a user-global
+# ~/.professor_osint.env (chmod 600) that works from any directory. Precedence:
+#   real environment var  >  project .env  >  ~/.professor_osint.env
 
 # Shodan — used by --spider (Attack Surface Mapping). With a key the tool queries
 # the authenticated api.shodan.io host endpoint instead of the anonymous InternetDB.
 SHODAN_API_KEY=
 
-# VirusTotal — reserved for future domain/subdomain enrichment.
+# VirusTotal — used by --harvester. Adds passive-DNS subdomains and a domain
+# reputation snapshot (throttled to the free tier's 4 requests/minute).
 VIRUSTOTAL_API_KEY=
 
-# Hunter.io — reserved for future email enumeration in --harvester.
+# Hunter.io — used by --harvester. Adds structured employee emails via the
+# domain-search endpoint on top of the scraped results.
 HUNTER_API_KEY=
 
 # ---------------------------------------------------------------------------

--- a/professor_osint/cli.py
+++ b/professor_osint/cli.py
@@ -27,6 +27,7 @@ def main():
     parser.add_argument("--i-am-authorized", dest="authorized", action="store_true", help="Confirm authorized use and skip the Social X-Ray consent prompt")
     parser.add_argument("--ai-analyze", dest="ai_analyze", action="store_true", help="AI Threat Intelligence Analysis (turn raw OSINT dumps into an analyst report)")
     parser.add_argument("--config-ai", dest="config_ai", action="store_true", help="Interactive setup wizard for the AI analyst (provider, model, endpoint)")
+    parser.add_argument("--config-api", dest="config_api", action="store_true", help="Interactive setup wizard for OSINT API keys (Shodan, VirusTotal, Hunter.io)")
     parser.add_argument("-r", "--recommend", action="store_true", help="Fetch OSINT tool recommendations from your Live API ecosystem")
     parser.add_argument("-p", "--playbook", action="store_true", help="Fetch ready-to-run Terminal commands for your target")
     parser.add_argument("-e", "--extract", choices=list(PATTERNS.keys()), help="Specific data pattern to extract from dumps")
@@ -40,6 +41,11 @@ def main():
     # Setup command: launch the AI provider wizard and exit before scanning.
     if args.config_ai:
         ProfessorOSINT(config_path=args.config).config_ai_wizard()
+        return
+
+    # Setup command: launch the OSINT API-key wizard and exit before scanning.
+    if args.config_api:
+        ProfessorOSINT(config_path=args.config).config_api_wizard()
         return
 
     if not args.query and not args.username and not args.social_xray:

--- a/professor_osint/common.py
+++ b/professor_osint/common.py
@@ -1,10 +1,22 @@
 """Shared runtime state: console, logging, optional dependencies."""
 import os
+import re
 import logging
 
 from rich.console import Console
 
 console = Console()
+
+# API keys frequently ride in query strings (?key=..., ?api_key=...). Scrub them
+# before anything reaches the log file or the terminal.
+_SECRET_QS_RE = re.compile(r"(?i)([?&](?:api[_-]?key|key|token|apikey)=)[^&\s]+")
+
+
+def redact(text):
+    """Return ``text`` with any key/token query-string values masked."""
+    if not text:
+        return text
+    return _SECRET_QS_RE.sub(r"\1***REDACTED***", str(text))
 
 # Configure Logging
 logging.basicConfig(
@@ -31,7 +43,12 @@ except ImportError:
 try:
     # Optional: load API keys from a local .env file if python-dotenv is installed.
     from dotenv import load_dotenv
+    # Project-level .env first (does not override real env vars), then a
+    # user-global file written by `--config-api` as a cross-directory fallback.
+    # load_dotenv never overrides already-set vars, so precedence is:
+    #   real environment  >  project .env  >  ~/.professor_osint.env
     load_dotenv()
+    load_dotenv(os.path.join(os.path.expanduser("~"), ".professor_osint.env"))
     HAS_DOTENV = True
 except ImportError:
     HAS_DOTENV = False

--- a/professor_osint/core/finder.py
+++ b/professor_osint/core/finder.py
@@ -14,6 +14,7 @@ from .net import NetMixin
 from ..reporting.database import DatabaseMixin
 from ..reporting.html_report import HtmlReportMixin
 from ..reporting.ai_analyzer import AiAnalyzerMixin
+from ..reporting.api_config import ApiConfigMixin
 from ..scanners.domain import DomainScannersMixin
 from ..scanners.people import PeopleScannersMixin
 from ..scanners.discovery import DiscoveryScannersMixin
@@ -25,6 +26,7 @@ class ProfessorOSINT(
     DatabaseMixin,
     HtmlReportMixin,
     AiAnalyzerMixin,
+    ApiConfigMixin,
     DomainScannersMixin,
     PeopleScannersMixin,
     DiscoveryScannersMixin,
@@ -92,7 +94,7 @@ class ProfessorOSINT(
         self.playbook_commands = []
         self.workspace_results = []
         self.phone_results = {}
-        self.harvester_results = {'subdomains': set(), 'emails': set()}
+        self.harvester_results = {'subdomains': set(), 'emails': set(), 'reputation': None}
         self.spider_results = {}
         self.awesome_results = []
         self.toolbox_results = []
@@ -332,7 +334,17 @@ class ProfessorOSINT(
             if self.harvester_results['emails']:
                 em_str = "\n".join(self.harvester_results['emails'])
                 table.add_row("Emails", em_str)
-                
+
+            rep = self.harvester_results.get('reputation')
+            if rep:
+                rep_str = (
+                    f"Score: {rep.get('score')}\n"
+                    f"Malicious: {rep.get('malicious', 0)}  |  "
+                    f"Suspicious: {rep.get('suspicious', 0)}  |  "
+                    f"Harmless: {rep.get('harmless', 0)}"
+                )
+                table.add_row("VT Reputation", rep_str)
+
             console.print(table)
             
         # Display Attack Surface Results

--- a/professor_osint/core/net.py
+++ b/professor_osint/core/net.py
@@ -30,6 +30,27 @@ class NetMixin:
                 raise
         return []
 
+    async def _throttle(self, name, per_minute):
+        """Space out calls to a named rate-limited API (e.g. VirusTotal: 4/min).
+
+        Sleeps just enough so consecutive calls under the same ``name`` honor a
+        minimum interval of ``60 / per_minute`` seconds. Timestamps live in a
+        lazily-created dict so this works across the tool's separate
+        ``asyncio.run()`` calls without touching ``__init__``.
+        """
+        if per_minute <= 0:
+            return
+        min_interval = 60.0 / per_minute
+        if not hasattr(self, "_rl_times"):
+            self._rl_times = {}
+        last = self._rl_times.get(name)
+        now = time.monotonic()
+        if last is not None:
+            wait = min_interval - (now - last)
+            if wait > 0:
+                await asyncio.sleep(wait)
+        self._rl_times[name] = time.monotonic()
+
     async def _resolve_async(self, host):
         """Resolve a hostname to an IP without blocking the event loop.
 

--- a/professor_osint/reporting/api_config.py
+++ b/professor_osint/reporting/api_config.py
@@ -1,0 +1,146 @@
+"""Interactive setup wizard for the OSINT API keys (``--config-api``).
+
+Mirrors the AI provider wizard in ``ai_analyzer.py`` but for the data-gathering
+providers (Shodan, VirusTotal, Hunter.io). Keys are written to a user-global
+env file, ``~/.professor_osint.env``, which ``common.py`` loads on startup as a
+fallback behind the project ``.env`` and real environment variables.
+
+Design notes:
+- Keys are the only secret written to disk, and the file is chmod 600.
+- Each key gets a best-effort live validation ping so the user learns whether it
+  actually works before relying on it mid-scan.
+- Blank input keeps the existing value; the wizard never clobbers a key you
+  don't re-enter.
+"""
+import os
+
+import requests
+
+from ..common import console
+
+# User-global env file loaded by common.py behind the project .env.
+API_ENV_PATH = os.path.join(os.path.expanduser("~"), ".professor_osint.env")
+
+# (label, env var, validator-key) for each supported OSINT provider.
+API_PROVIDERS = [
+    ("Shodan", "SHODAN_API_KEY", "shodan"),
+    ("VirusTotal", "VIRUSTOTAL_API_KEY", "virustotal"),
+    ("Hunter.io", "HUNTER_API_KEY", "hunter"),
+]
+
+
+def _mask(value):
+    """Return a masked preview of a secret (or 'not set')."""
+    if not value:
+        return "[dim]not set[/dim]"
+    if len(value) <= 8:
+        return "•" * len(value)
+    return f"{value[:4]}…{value[-4:]}"
+
+
+class ApiConfigMixin:
+    """Adds the interactive OSINT API-key setup wizard to the orchestrator."""
+
+    def _read_api_env_file(self):
+        """Return the {KEY: value} pairs currently saved in the env file."""
+        data = {}
+        try:
+            with open(API_ENV_PATH, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line or line.startswith("#") or "=" not in line:
+                        continue
+                    k, v = line.split("=", 1)
+                    data[k.strip()] = v.strip()
+        except (FileNotFoundError, OSError):
+            pass
+        return data
+
+    def _write_api_env_file(self, values):
+        """Persist {KEY: value} to the env file with 600 perms."""
+        lines = [
+            "# Professor OSINT API keys — written by `professor-osint --config-api`.",
+            "# This file is loaded automatically on startup. Keep it private.",
+            "",
+        ]
+        for _, env_var, _ in API_PROVIDERS:
+            lines.append(f"{env_var}={values.get(env_var, '')}")
+        with open(API_ENV_PATH, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
+        try:
+            os.chmod(API_ENV_PATH, 0o600)
+        except OSError:
+            pass
+
+    def _validate_api_key(self, kind, key):
+        """Best-effort live validation ping. Returns True/False/None(unknown)."""
+        try:
+            if kind == "shodan":
+                r = requests.get(
+                    f"https://api.shodan.io/api-info?key={key}", timeout=15
+                )
+                return r.status_code == 200
+            if kind == "virustotal":
+                r = requests.get(
+                    "https://www.virustotal.com/api/v3/users/current",
+                    headers={"x-apikey": key}, timeout=15,
+                )
+                return r.status_code == 200
+            if kind == "hunter":
+                r = requests.get(
+                    f"https://api.hunter.io/v2/account?api_key={key}", timeout=15
+                )
+                return r.status_code == 200
+        except requests.exceptions.RequestException:
+            return None
+        return None
+
+    def config_api_wizard(self):
+        """Interactive setup + live validation for the OSINT API keys."""
+        console.print(
+            "\n[bold bright_green]🔑 Professor OSINT — API Key Setup[/bold bright_green]"
+        )
+        console.print(
+            "[dim]Leave a prompt blank to keep the current value. Keys are saved to "
+            f"{API_ENV_PATH} (chmod 600).[/dim]\n"
+        )
+
+        # Seed with whatever is already active (env / project .env / this file).
+        saved = self._read_api_env_file()
+        values = {}
+        for label, env_var, kind in API_PROVIDERS:
+            current = os.getenv(env_var) or saved.get(env_var, "")
+            console.print(f"[cyan]{label}[/cyan] — current: {_mask(current)}")
+            try:
+                entered = input(f"Enter {label} API Key (blank = keep/skip): ").strip()
+            except (EOFError, KeyboardInterrupt):
+                console.print("\n[yellow]Setup aborted. Nothing was saved.[/yellow]")
+                return
+
+            key = entered or current
+            values[env_var] = key
+
+            if entered:
+                console.print("[cyan]Validating key...[/cyan]")
+                ok = self._validate_api_key(kind, key)
+                if ok is True:
+                    console.print(f"[bold green][+] {label} key is valid.[/bold green]\n")
+                elif ok is False:
+                    console.print(
+                        f"[bold red][!] {label} key was rejected by the provider. "
+                        f"Saving anyway — re-run to fix.[/bold red]\n"
+                    )
+                else:
+                    console.print(
+                        f"[yellow][!] Could not reach {label} to validate "
+                        f"(offline?). Saving anyway.[/yellow]\n"
+                    )
+            else:
+                console.print("")
+
+        self._write_api_env_file(values)
+        console.print(f"[bold green][+] API keys saved to {API_ENV_PATH}[/bold green]")
+        console.print(
+            "[dim]These load automatically on your next scan. A project-level .env "
+            "or a real environment variable still takes precedence.[/dim]"
+        )

--- a/professor_osint/reporting/html_report.py
+++ b/professor_osint/reporting/html_report.py
@@ -168,7 +168,18 @@ class HtmlReportMixin:
                 for em in self.harvester_results['emails']:
                     html_content += f"<li>{em}</li>"
                 html_content += "</ul>"
-                
+            rep = self.harvester_results.get('reputation')
+            if rep:
+                html_content += (
+                    "<h3>VirusTotal Reputation</h3>"
+                    "<div class=\"webcheck-box\">"
+                    f"<div class=\"webcheck-item\"><strong>Reputation Score:</strong> {rep.get('score')}</div>"
+                    f"<div class=\"webcheck-item\"><strong>Malicious:</strong> {rep.get('malicious', 0)}</div>"
+                    f"<div class=\"webcheck-item\"><strong>Suspicious:</strong> {rep.get('suspicious', 0)}</div>"
+                    f"<div class=\"webcheck-item\"><strong>Harmless:</strong> {rep.get('harmless', 0)}</div>"
+                    "</div>"
+                )
+
         if self.spider_results:
             html_content += f"""
             <h2>🕸️ Attack Surface Mapping Engine</h2>

--- a/professor_osint/scanners/domain.py
+++ b/professor_osint/scanners/domain.py
@@ -2,10 +2,11 @@ import re
 import socket
 import random
 import asyncio
+import logging
 
 import aiohttp
 
-from ..common import console
+from ..common import console, redact
 from ..constants import USER_AGENTS
 
 
@@ -58,9 +59,94 @@ class DomainScannersMixin:
                     
         except Exception as e:
             console.print(f"[bold red][!] Harvester Error: {e}[/bold red]")
-            
+
+        # Optional premium enrichment — layered on top of the free scrape above.
+        # Each upgrade is fully gated on a key and degrades gracefully if absent.
+        await self._enrich_virustotal(self.query)
+        await self._enrich_hunter(self.query)
+
         if self.harvester_results['subdomains'] or self.harvester_results['emails']:
             console.print(f"[bold green][+] Harvested {len(self.harvester_results['subdomains'])} Subdomains and {len(self.harvester_results['emails'])} Emails![/bold green]")
+
+    async def _enrich_virustotal(self, domain):
+        """Augment harvester results with VirusTotal v3 data when a key is set.
+
+        Adds passive-DNS subdomains and records domain reputation. VT's free tier
+        allows 4 requests/minute, so every call is throttled. Any failure is
+        logged and swallowed — the scrape results already stand on their own.
+        """
+        vt_key = self.api_keys.get('virustotal')
+        if not vt_key or not domain:
+            return
+
+        headers = {'x-apikey': vt_key, 'Accept': 'application/json'}
+        base = f"https://www.virustotal.com/api/v3/domains/{domain}"
+        try:
+            timeout = aiohttp.ClientTimeout(total=20)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                # Passive-DNS subdomains.
+                await self._throttle('virustotal', per_minute=4)
+                async with session.get(f"{base}/subdomains?limit=40", headers=headers) as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        subs = [item.get('id') for item in data.get('data', []) if item.get('id')]
+                        for sub in subs:
+                            self.harvester_results['subdomains'].add(sub)
+                        console.print(f"[bold green][+] VirusTotal added {len(subs)} subdomain(s) via authenticated API![/bold green]")
+                    elif resp.status in (401, 403):
+                        console.print("[bold yellow][!] VirusTotal key rejected — skipping VT enrichment.[/bold yellow]")
+                        return
+                    elif resp.status == 429:
+                        console.print("[bold yellow][!] VirusTotal rate limit hit — skipping VT enrichment.[/bold yellow]")
+                        return
+
+                # Domain reputation snapshot.
+                await self._throttle('virustotal', per_minute=4)
+                async with session.get(base, headers=headers) as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        attrs = data.get('data', {}).get('attributes', {})
+                        stats = attrs.get('last_analysis_stats', {})
+                        self.harvester_results['reputation'] = {
+                            'score': attrs.get('reputation'),
+                            'malicious': stats.get('malicious', 0),
+                            'suspicious': stats.get('suspicious', 0),
+                            'harmless': stats.get('harmless', 0),
+                        }
+                        console.print(
+                            f"[bold green][+] VirusTotal reputation: "
+                            f"{self.harvester_results['reputation']['malicious']} malicious / "
+                            f"{self.harvester_results['reputation']['suspicious']} suspicious detections.[/bold green]"
+                        )
+        except Exception as e:
+            logging.error("VirusTotal enrichment failed for %s: %s", domain, redact(str(e)))
+            console.print("[bold yellow][!] VirusTotal enrichment error — continuing with scraped data.[/bold yellow]")
+
+    async def _enrich_hunter(self, domain):
+        """Augment harvested emails via Hunter.io domain-search when a key is set."""
+        hunter_key = self.api_keys.get('hunter')
+        if not hunter_key or not domain:
+            return
+
+        url = f"https://api.hunter.io/v2/domain-search?domain={domain}&api_key={hunter_key}&limit=50"
+        try:
+            timeout = aiohttp.ClientTimeout(total=20)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                await self._throttle('hunter', per_minute=15)
+                async with session.get(url) as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        emails = [e.get('value') for e in data.get('data', {}).get('emails', []) if e.get('value')]
+                        for email in emails:
+                            self.harvester_results['emails'].add(email)
+                        console.print(f"[bold green][+] Hunter.io added {len(emails)} structured email(s) via authenticated API![/bold green]")
+                    elif resp.status in (401, 403):
+                        console.print("[bold yellow][!] Hunter.io key rejected — skipping Hunter enrichment.[/bold yellow]")
+                    elif resp.status == 429:
+                        console.print("[bold yellow][!] Hunter.io rate limit hit — skipping Hunter enrichment.[/bold yellow]")
+        except Exception as e:
+            logging.error("Hunter.io enrichment failed for %s: %s", domain, redact(str(e)))
+            console.print("[bold yellow][!] Hunter.io enrichment error — continuing with scraped data.[/bold yellow]")
 
     async def spider_search_async(self):
         if not self.spider or not self.query:


### PR DESCRIPTION
….io enrichment

Extend the harvester with optional premium enrichment that layers official API data on top of the existing anonymous scraping, preserving the zero-key default while upgrading gracefully when credentials are present.

- Add VirusTotal v3 enrichment (passive-DNS subdomains + domain reputation) and Hunter.io domain-search email enumeration to the harvester engine, each fully gated on a key with graceful fallback on rejection or rate limit.
- Introduce a shared async rate-limiter (NetMixin._throttle) honoring the VirusTotal free-tier ceiling of 4 requests/minute.
- Add an interactive --config-api setup wizard that validates and persists Shodan/VirusTotal/Hunter keys to a user-global ~/.professor_osint.env (chmod 600), loaded behind the project .env and real environment vars.
- Add a redact() helper to scrub API keys from query strings before logging.
- Surface VirusTotal reputation in the terminal report and HTML output.
- Document the key-management workflow in .env.example.